### PR TITLE
Add a `flake.nix` to reproduce Shanocast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# nix results
+*result*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,0 @@
-FROM ubuntu:20.04
-RUN apt-get update -y
-RUN apt-get -y install libsdl2-2.0-0 ffmpeg libatomic1
-COPY cast_receiver /root
-WORKDIR /root
-ENTRYPOINT ["/root/cast_receiver"]

--- a/README.md
+++ b/README.md
@@ -1,28 +1,29 @@
 Shanocast is a Google Chromecast receiver which works with the Google Chrome browser. Demo:
 
-
-
 https://github.com/rgerganov/shanocast/assets/271616/51886018-d6be-4d56-beb7-de1c6ad7e284
-
-
 
 # Usage
 
-Shanocast runs on Linux and is available as docker image:
+Shanocast runs on Linux and is reproducible via a Nix Flake
+
+Get Nix and enable flakes, for example via the DetSys Nix installer
+
+```
+curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+```
+
+Or if you prefer a single 21M~ file, get a statically compiled Nix binary
+
+```
+curl -L https://hydra.nixos.org/job/nix/master/buildStatic.x86_64-linux/latest/download-by-type/file/binary-dist > nix
+chmod +x ./nix
+```
 
 ```bash
-$ docker pull rgerganov/shanocast
+$ nix run .#shanocast lo
 ```
 
-As Shanocast runs in a container, you need to enable access to your X11 server (use with caution, this has security implications):
-```
-$ xhost +
-```
-
-The container can be started like this, the last parameter specifies the network interface where the server runs:
-```bash
-$ docker run --network host --device /dev/snd --device /dev/dri -it -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix shanocast lo
-```
+the final argument `lo` specifies the network interface where the cast_receiver runs.
 
 Finally, start Google Chrome and Shanocast should be listed as available for casting.
 

--- a/cast_receiver.nix
+++ b/cast_receiver.nix
@@ -1,0 +1,54 @@
+{ stdenv
+, darwin
+, lib
+, ninja
+, gn
+, pkg-config
+, python3
+, ffmpeg
+, SDL2
+, src
+}:
+stdenv.mkDerivation {
+  name = "shanocast";
+  inherit src;
+  NIX_CFLAGS_COMPILE =
+    if stdenv.isLinux
+    then
+      (toString [ "-Wno-error=maybe-uninitialized" "-Wno-error=stringop-overflow" "-Wno-error=ignored-attributes" ])
+    else
+      (toString ["-Wno-error=uninitialized"]);
+  ninjaFlags = [ "cast_receiver" ];
+  prePatch = ''
+    substituteInPlace build/config/sysroot.gni --replace 'sysroot_platform = "bullseye"' ""
+    substituteInPlace build/config/BUILD.gn --replace '--target=aarch64-linux-gnu' ""
+  '';
+  gnFlags = [
+    "is_clang=${lib.boolToString stdenv.cc.isClang}"
+    "cast_allow_developer_certificate=true"
+    "have_ffmpeg=true"
+    "have_libsdl2=true"
+  ];
+  installPhase = ''
+    mkdir -p $out/bin
+    mv cast_receiver $out/bin/shanocast
+  '';
+  patches = [
+    ./shanocast.patch
+  ];
+  buildInputs = [
+    ffmpeg
+    SDL2
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.IOKit
+  ];
+  nativeBuildInputs = [
+    gn
+    ninja
+    pkg-config
+    python3
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.cctools
+  ];
+}
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,83 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1701473968,
+        "narHash": "sha256-YcVE5emp1qQ8ieHUnxt1wCZCC3ZfAS+SRRWZ2TMda7E=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "34fed993f1674c8d06d58b37ce1e0fe5eebcb9f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1703255338,
+        "narHash": "sha256-Z6wfYJQKmDN9xciTwU3cOiOk+NElxdZwy/FiHctCzjU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6df37dc6a77654682fe9f071c62b4242b5342e04",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1701253981,
+        "narHash": "sha256-ztaDIyZ7HrTAfEEUt9AtTDNoCYxUdSd6NrRHaYOIxtk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e92039b55bcd58469325ded85d4f58dd5a4eaf58",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "openscreen": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1695839408,
+        "narHash": "sha256-2zBoL+UfQeYm7EVj1hZoJE0Q04KHjpx5csYQsWvlzYU=",
+        "rev": "934f2462ad01c407a596641dbc611df49e2017b4",
+        "revCount": 1184,
+        "submodules": true,
+        "type": "git",
+        "url": "https://chromium.googlesource.com/openscreen.git"
+      },
+      "original": {
+        "rev": "934f2462ad01c407a596641dbc611df49e2017b4",
+        "submodules": true,
+        "type": "git",
+        "url": "https://chromium.googlesource.com/openscreen.git"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "openscreen": "openscreen"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  description = "Description for the project";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    openscreen = {
+      url = "git+https://chromium.googlesource.com/openscreen.git?rev=934f2462ad01c407a596641dbc611df49e2017b4&submodules=1";
+      flake = false;
+    };
+  };
+
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      # arm64 only supported on linux according to openscreen upstream
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
+      perSystem = { config, self', inputs', pkgs, system, ... }: {
+        packages = rec {
+          shanocast = default;
+          default = pkgs.callPackage ./cast_receiver.nix { src = inputs.openscreen; };
+        };
+      };
+    };
+}


### PR DESCRIPTION
This adds a Nix flake to make shanocast reproducible and easy to build for all platforms, I have updated the README.md to reflect this.

In conclusion, this fills in all of the missing details that were left out of the blog post and README, should somebody want to reproduce this themselves, such as:

- Ninja flags
- Compiler flags
- GN flags
- Dependencies
- Commit revisions to base the patch on

## Linux

Works fine, even on a Raspberry Pi, though KMS+DRM doesn't play at the right resolution from SDL2, so spawning via Sway/Cage is preferable, streams from chromium eventually cut out and stop playing, so it's not usable full time.

![image](https://github.com/rgerganov/shanocast/assets/26458780/c3891783-8cfb-4499-8244-cd10da0bcb2c)

## MacOS

After disabling the mDNS services taking up port 5353 (Bonjour?)  via `launchctl` Chromium seems unable to find Shanocast.

`sudo launchctl unload /System/Library/LaunchDaemons/com.apple.mDNSResponder.plist`

![image](https://github.com/rgerganov/shanocast/assets/26458780/6c9dc4dd-a987-440d-9d46-321b7bb4c199)
