### PR TITLE
Add Docker support for building and running shanocast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 # nix results
 *result*
+bin/
+bin/shanocast
+shanocast
+*.crt
+*.key

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ https://github.com/rgerganov/shanocast/assets/271616/51886018-d6be-4d56-beb7-de1
 
 # Usage
 
-Shanocast runs on Linux and is reproducible via a Nix Flake
+Shanocast runs on Linux and is reproducible via a Nix Flake or Docker.
+
+## Using Nix
 
 Get Nix and enable flakes, for example via the DetSys Nix installer
 
@@ -25,9 +27,29 @@ $ nix run .#shanocast lo
 
 the final argument `lo` specifies the network interface where the cast_receiver runs.
 
+## Using Docker
+
+Shanocast can also be built and run using Docker. For detailed instructions, see the [Docker README](docker/README.md).
+
+Basic usage:
+
+```bash
+# Build the Docker images
+./docker/build-images.sh
+
+# Run shanocast (will prompt for network interface)
+./docker/run-shanocast.sh
+```
+
 Finally, start Google Chrome and Shanocast should be listed as available for casting.
 
 # Building
+
+## Using Nix or Docker
+
+See the Usage section above for building with Nix or Docker.
+
+## Manual Build
 
 Build [Openscreen](https://chromium.googlesource.com/openscreen/) (commit 2a4dbe65) with this [patch](shanocast.patch)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,54 @@
+FROM beardedtek/shanocast-builder:base AS builder
+
+# Fix compiler warnings and create FFmpeg include symlinks
+RUN cd openscreen && \
+    # Fix the ignored-attributes warning by directly modifying the file
+    sed -i '127s/.*/using FileUniquePtr = std::unique_ptr<FILE, int(*)(FILE*)>;/' cast/receiver/channel/static_credentials.cc && \
+    # Fix uninitialized variable warnings in socket code
+    sed -i '226s/int domain;/int domain = 0;/' platform/impl/stream_socket_posix.cc && \
+    sed -i '106s/int domain;/int domain = 0;/' platform/impl/udp_socket_posix.cc && \
+    # Create complete symlinks for FFmpeg headers
+    mkdir -p /usr/local/include && \
+    ln -sf /usr/include/ffmpeg/libavcodec /usr/local/include/ && \
+    ln -sf /usr/include/ffmpeg/libavformat /usr/local/include/ && \
+    ln -sf /usr/include/ffmpeg/libavutil /usr/local/include/ && \
+    ln -sf /usr/include/ffmpeg/libswscale /usr/local/include/
+
+# Build binary
+RUN cd openscreen && \
+    # Apply necessary compiler flags and build settings
+    gn gen out/Default --args="is_debug=false use_custom_libcxx=false treat_warnings_as_errors=false have_ffmpeg=true have_libsdl2=true cast_allow_developer_certificate=true is_clang=false" && \
+    # Add FFmpeg include paths and disable specific warnings
+    sed -i 's/-I..\/..\"/-I..\/..\"/g' out/Default/toolchain.ninja && \
+    sed -i 's/-I..\/..\"/\"-I..\/..\" \"-I\/usr\/local\/include\"/' out/Default/toolchain.ninja && \
+    sed -i 's/-Werror/-Werror -Wno-ignored-attributes -Wno-maybe-uninitialized/' out/Default/toolchain.ninja && \
+    # Build with ninja
+    ninja -C out/Default cast_receiver && \
+    cp out/Default/cast_receiver /build/shanocast
+
+# Create a smaller runtime image
+FROM fedora:42
+
+# Install runtime dependencies
+RUN dnf -y update && dnf -y install \
+    ffmpeg-free \
+    SDL2 \
+    mesa-dri-drivers \
+    mesa-libGL \
+    libva \
+    libvdpau \
+    pulseaudio-libs \
+    alsa-lib \
+    avahi \
+    avahi-tools \
+    nss-mdns \
+    iproute
+
+# Create app directory
+WORKDIR /app
+
+# Copy binary from builder stage
+COPY --from=builder /build/shanocast /app/
+
+# Set the entrypoint
+ENTRYPOINT ["/app/shanocast"] 

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,0 +1,40 @@
+FROM fedora:42 AS builder
+
+# Install build dependencies
+RUN dnf -y update && dnf -y install \
+    gcc-c++ \
+    ninja-build \
+    gn \
+    git \
+    python3 \
+    python3-pip \
+    pkg-config \
+    ffmpeg-free-devel \
+    libavcodec-free-devel \
+    libavformat-free-devel \
+    libavutil-free-devel \
+    libswscale-free-devel \
+    SDL2-devel \
+    which \
+    make \
+    cmake \
+    curl \
+    patch
+
+# Create build directory
+WORKDIR /build
+
+# Clone and patch openscreen
+RUN git clone --recurse-submodules https://chromium.googlesource.com/openscreen.git && \
+    cd openscreen && \
+    git checkout 934f2462ad01c407a596641dbc611df49e2017b4
+
+# Copy patch file
+COPY shanocast.patch /build/
+
+# Apply patch
+RUN cd openscreen && \
+    patch -p1 < /build/shanocast.patch
+
+# Set the default command to bash
+CMD ["/bin/bash"] 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,126 @@
+# Shanocast Docker Build
+
+This directory contains files to build Shanocast using Docker with a Fedora 42 base image.
+
+## Two-Stage Build Process
+
+The build process is split into two stages:
+
+1. **Base Builder Image**: Contains the environment setup and patched openscreen repository
+2. **Final Image**: Builds the shanocast binary and creates a minimal runtime container
+
+## Building with Docker
+
+To build both Docker images:
+
+```bash
+./build-images.sh
+```
+
+This will create two Docker images:
+- `beardedtek/shanocast-builder:base` - The base builder image with the patched openscreen repository
+- `beardedtek/shanocast:latest` - The final runtime image with the shanocast binary
+
+You can also build them separately:
+
+```bash
+# Build only the base image
+docker build -t beardedtek/shanocast-builder:base -f Dockerfile.base .
+
+# Build the final image (requires the base image)
+docker build -t beardedtek/shanocast:latest .
+```
+
+## Running with Docker
+
+You can run the container directly with Docker:
+
+```bash
+# Replace 'eth0' with your network interface name
+docker run --network host beardedtek/shanocast:latest eth0
+```
+
+Or using Docker Compose:
+
+```bash
+# Edit docker-compose.yml to set your network interface if needed
+docker-compose up -d
+```
+
+You can also use the provided run script, which will prompt you for a network interface:
+
+```bash
+./run-shanocast.sh
+```
+
+## Configuration
+
+The Shanocast binary requires a network interface name as an argument. By default, the docker-compose.yml file is configured to use 'eth0'.
+
+### Network Interface Configuration
+
+There are several ways to specify the network interface:
+
+1. **Docker Run Command**: Pass the interface name as an argument
+   ```bash
+   docker run --network host beardedtek/shanocast:latest enp42s0
+   ```
+
+2. **Docker Compose**: Edit the `command` field in docker-compose.yml
+   ```yaml
+   command: enp42s0  # Replace with your network interface
+   ```
+
+3. **Environment Variable**: Set the INTERFACE environment variable
+   ```bash
+   INTERFACE=enp42s0 docker-compose up -d
+   ```
+   or
+   ```bash
+   export INTERFACE=enp42s0
+   docker-compose up -d
+   ```
+
+4. **Run Script**: The run-shanocast.sh script will prompt for an interface if not specified
+
+Common network interface names:
+- `eth0`, `enp0s3`: Ethernet interfaces
+- `wlan0`, `wlp2s0`: WiFi interfaces
+- `lo`: Loopback interface (for local testing)
+
+## Extracting the Binary
+
+If you want to extract the binary from the Docker container to run it directly on your host system:
+
+```bash
+./extract-binary.sh
+```
+
+Note that the extracted binary will require the appropriate runtime dependencies (ffmpeg-free and SDL2) to be installed on the host system.
+
+## Display and Audio Support
+
+The docker-compose.yml file includes configuration for accessing the host's display and audio devices, allowing shanocast to render video and play audio directly on your system.
+
+## Development
+
+If you need to modify the shanocast patch or build process:
+
+1. Edit the `shanocast.patch` file
+2. Rebuild the base image: `docker build -t beardedtek/shanocast-builder:base -f Dockerfile.base .`
+3. Rebuild the final image: `docker build -t beardedtek/shanocast:latest .`
+
+## Troubleshooting
+
+1. If you encounter networking issues, make sure you're using the correct network interface name.
+2. The container must run with host networking (`--network host`) to properly discover and advertise the Chromecast service.
+3. To see available network interfaces on your system, run:
+   ```bash
+   ip addr
+   ```
+4. For display issues, try running `xhost +local:` on the host before starting the container.
+5. For audio issues, check if your user is in the `audio` group: `groups $USER`
+
+## Usage
+
+Once running, open Google Chrome on a device on the same network, and Shanocast should be listed as an available casting device. 

--- a/docker/build-images.sh
+++ b/docker/build-images.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# Get the script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Change to root directory
+cd "$ROOT_DIR"
+
+echo "Building base image (beardedtek/shanocast-builder:base)..."
+docker build -t beardedtek/shanocast-builder:base -f docker/Dockerfile.base .
+
+echo "Building shanocast image (beardedtek/shanocast:latest)..."
+docker build -t beardedtek/shanocast:latest -f docker/Dockerfile .
+
+echo "Done! Images built successfully:"
+echo "  - beardedtek/shanocast-builder:base"
+echo "  - beardedtek/shanocast:latest"
+echo
+echo "You can run shanocast with: docker run --network host beardedtek/shanocast:latest <network_interface>" 

--- a/docker/compose-up.sh
+++ b/docker/compose-up.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Get the script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Change to script directory
+cd "$SCRIPT_DIR"
+
+# Use INTERFACE env var if set, otherwise prompt for input
+if [ -z "$INTERFACE" ]; then
+  # Show available network interfaces
+  echo "Available network interfaces:"
+  ip -o addr show | grep -v "lo" | awk '{print $2}' | uniq | sort
+
+  echo ""
+  echo "Choose a network interface from the list above (default: enp42s0):"
+  read -r INTERFACE
+
+  # Set default if empty
+  if [ -z "$INTERFACE" ]; then
+    INTERFACE="enp42s0"
+  fi
+else
+  echo "Using network interface from environment variable: $INTERFACE"
+fi
+
+echo "Starting shanocast with interface: $INTERFACE"
+
+# Export the INTERFACE variable for docker-compose
+export INTERFACE
+
+# Run docker-compose
+docker-compose up -d
+
+echo "Shanocast is running! You should be able to see it as a casting device in Chrome."
+echo "To view logs: docker logs -f shanocast"
+echo "To stop: docker-compose down" 

--- a/docker/debug-build.sh
+++ b/docker/debug-build.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# Get the script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Change to root directory
+cd "$ROOT_DIR"
+
+echo "Creating debug container..."
+docker run --rm -it \
+  -v "$(pwd):/build" \
+  -w /build \
+  --name shanocast_debug \
+  fedora:42 bash -c "
+    echo '=== Installing build dependencies ==='
+    dnf -y update && dnf -y install \
+      gcc-c++ \
+      ninja-build \
+      gn \
+      git \
+      python3 \
+      python3-pip \
+      pkg-config \
+      ffmpeg-free-devel \
+      libavcodec-free-devel \
+      libavformat-free-devel \
+      libavutil-free-devel \
+      libswscale-free-devel \
+      SDL2-devel \
+      which \
+      make \
+      cmake \
+      curl \
+      patch
+
+    echo '=== Checking FFmpeg headers ==='
+    find /usr -name 'avcodec.h' | grep -i ffmpeg
+    pkg-config --cflags libavcodec
+    pkg-config --libs libavcodec
+    echo 'FFmpeg include path:'
+    pkg-config --variable=includedir libavcodec
+    
+    echo '=== Creating FFmpeg symlinks ==='
+    mkdir -p /usr/local/include
+    ln -sf /usr/include/ffmpeg/libavcodec /usr/local/include/
+    ln -sf /usr/include/ffmpeg/libavformat /usr/local/include/
+    ln -sf /usr/include/ffmpeg/libavutil /usr/local/include/
+    ln -sf /usr/include/ffmpeg/libswscale /usr/local/include/
+    
+    echo '=== Testing FFmpeg include path ==='
+    cat > test_ffmpeg.c << EOF
+    #include <libavcodec/avcodec.h>
+    int main() { return 0; }
+    EOF
+    gcc -c test_ffmpeg.c -o test_ffmpeg.o -I/usr/local/include && echo 'Include works with -I/usr/local/include!'
+    
+    echo '=== Checking SDL2 headers ==='
+    find /usr -name 'SDL.h' | grep -i sdl2
+    pkg-config --cflags sdl2
+    pkg-config --libs sdl2
+    
+    echo '=== Cloning and patching openscreen ==='
+    if [ ! -d 'openscreen' ]; then
+      git clone --recurse-submodules https://chromium.googlesource.com/openscreen.git
+      cd openscreen
+      git checkout 934f2462ad01c407a596641dbc611df49e2017b4
+      patch -p1 < /build/shanocast.patch
+    else
+      echo 'Using existing openscreen directory'
+      cd openscreen
+    fi
+    
+    echo '=== Fixing compiler warnings ==='
+    sed -i '127s/.*/using FileUniquePtr = std::unique_ptr<FILE, int(*)(FILE*)>;/' cast/receiver/channel/static_credentials.cc
+    sed -i '226s/int domain;/int domain = 0;/' platform/impl/stream_socket_posix.cc
+    sed -i '106s/int domain;/int domain = 0;/' platform/impl/udp_socket_posix.cc
+    
+    echo '=== Generating build files ==='
+    gn gen out/Default --args=\"is_debug=false use_custom_libcxx=false treat_warnings_as_errors=false have_ffmpeg=true have_libsdl2=true cast_allow_developer_certificate=true is_clang=false\"
+    
+    echo '=== Adding FFmpeg include paths and disabling warnings ==='
+    sed -i 's/-I..\\/..\"/-I..\\/..\" \"-I\\/usr\\/local\\/include\"/' out/Default/toolchain.ninja
+    sed -i 's/-Werror/-Werror -Wno-ignored-attributes -Wno-maybe-uninitialized/' out/Default/toolchain.ninja
+    
+    echo '=== Starting interactive shell ==='
+    echo 'You can now explore the environment and test the build manually'
+    echo 'To build, run: cd openscreen && ninja -C out/Default cast_receiver'
+    echo 'Type \"exit\" when done'
+    bash
+  " 

--- a/docker/debug-run.sh
+++ b/docker/debug-run.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Get the script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Change to root directory
+cd "$ROOT_DIR"
+
+# Extract the binary from the container if it doesn't exist
+if [ ! -f "./shanocast" ]; then
+  echo "Extracting shanocast binary from container..."
+  docker create --name temp_container beardedtek/shanocast:latest
+  docker cp temp_container:/app/shanocast ./shanocast
+  docker rm temp_container
+fi
+
+# Make it executable
+chmod +x ./shanocast
+
+# Get the network interface
+if [ -z "$1" ]; then
+  echo "Available network interfaces:"
+  ip -o addr show | grep -v "lo" | awk '{print $2}' | uniq | sort
+  echo ""
+  echo "Please provide a network interface (e.g. ./docker/debug-run.sh enp42s0)"
+  exit 1
+fi
+
+interface="$1"
+echo "Running shanocast with interface: $interface"
+
+# Run with sudo to allow binding to privileged ports
+sudo ./shanocast "$interface" 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3'
+
+services:
+  shanocast:
+    image: beardedtek/shanocast:latest
+    container_name: shanocast
+    network_mode: "host"  # Use host networking to properly detect network interfaces
+    restart: unless-stopped
+    command: ${INTERFACE:-enp42s0}  # Use INTERFACE env var or default to enp42s0
+    # Display and audio access
+    environment:
+      - DISPLAY=${DISPLAY}
+      - PULSE_SERVER=unix:${XDG_RUNTIME_DIR}/pulse/native
+      - XDG_RUNTIME_DIR=/tmp/runtime-dir
+      - WAYLAND_DISPLAY=${WAYLAND_DISPLAY}
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix  # X11 socket
+      - ${XDG_RUNTIME_DIR}/pulse:/tmp/runtime-dir/pulse  # PulseAudio socket
+      - /dev/dri:/dev/dri  # GPU access
+      - /dev/snd:/dev/snd  # ALSA sound devices
+    devices:
+      - /dev/snd:/dev/snd  # Sound devices
+    cap_add:
+      - NET_BIND_SERVICE  # Allow binding to privileged ports
+      - NET_ADMIN  # Allow network interface configuration
+    privileged: true  # Required for full network access
+    group_add:
+      - audio  # Add container to audio group
+      - video  # Add container to video group
+    # Alternatively, you can use the following to specify a different network interface:
+    # command: lo  # For local testing 

--- a/docker/extract-binary.sh
+++ b/docker/extract-binary.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+echo "Building shanocast Docker images..."
+./build-images.sh
+
+echo "Creating temporary container..."
+docker create --name temp_shanocast beardedtek/shanocast:latest
+
+echo "Extracting binary..."
+mkdir -p ../bin
+docker cp temp_shanocast:/app/shanocast ../bin/shanocast
+
+echo "Removing temporary container..."
+docker rm temp_shanocast
+
+echo "Done! Binary is available at: $(pwd)/shanocast"
+echo "You can run it with: ./shanocast <network_interface>"
+echo ""
+echo "Note: This binary requires ffmpeg-free and SDL2 to be installed on your system."
+echo "On Fedora: sudo dnf install ffmpeg-free SDL2" 

--- a/docker/run-shanocast.sh
+++ b/docker/run-shanocast.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Get the script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Change to root directory
+cd "$ROOT_DIR"
+
+# Use INTERFACE env var if set, otherwise prompt for input
+if [ -z "$INTERFACE" ]; then
+  # Show available network interfaces
+  echo "Available network interfaces:"
+  ip -o addr show | grep -v "lo" | awk '{print $2}' | uniq | sort
+
+  echo ""
+  echo "Choose a network interface from the list above (default: enp42s0):"
+  read -r interface
+
+  # Set default if empty
+  if [ -z "$interface" ]; then
+    interface="enp42s0"
+  fi
+else
+  interface="$INTERFACE"
+  echo "Using network interface from environment variable: $interface"
+fi
+
+echo "Starting shanocast with interface: $interface"
+
+# Check if the container already exists
+if docker ps -a --format '{{.Names}}' | grep -q "^shanocast$"; then
+  echo "Removing existing shanocast container..."
+  docker rm -f shanocast
+fi
+
+# Ensure XDG_RUNTIME_DIR is set
+if [ -z "$XDG_RUNTIME_DIR" ]; then
+  export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+fi
+
+# Run the container with display and audio support
+docker run --name shanocast \
+  --network host \
+  -e DISPLAY="$DISPLAY" \
+  -e PULSE_SERVER="unix:${XDG_RUNTIME_DIR}/pulse/native" \
+  -e XDG_RUNTIME_DIR="/tmp/runtime-dir" \
+  -e WAYLAND_DISPLAY="$WAYLAND_DISPLAY" \
+  -v /tmp/.X11-unix:/tmp/.X11-unix \
+  -v "${XDG_RUNTIME_DIR}/pulse:/tmp/runtime-dir/pulse" \
+  -v /dev/dri:/dev/dri \
+  -v /dev/snd:/dev/snd \
+  --device /dev/snd \
+  --cap-add NET_BIND_SERVICE \
+  --cap-add NET_ADMIN \
+  --privileged \
+  --group-add audio \
+  --group-add video \
+  -d beardedtek/shanocast:latest "$interface"
+
+echo "Shanocast is running! You should be able to see it as a casting device in Chrome."
+echo "To view logs: docker logs -f shanocast"
+echo "To stop: docker stop shanocast" 


### PR DESCRIPTION
This pull request adds Docker support for building and running shanocast.

Key features:
- Two-stage Docker build process for efficient builds
- Support for running with display and audio output
- Environment variable (INTERFACE) support for network interface selection
- Comprehensive documentation in docker/README.md
- Scripts for building, running, and extracting the binary

The Docker setup uses Fedora 42 as the base image and includes all necessary dependencies for building and running shanocast.